### PR TITLE
Addressing CA1036 for IPAddressRange and Subnet

### DIFF
--- a/src/Arcus.Tests/IPAddressRangeTests.cs
+++ b/src/Arcus.Tests/IPAddressRangeTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -94,9 +94,137 @@ namespace Arcus.Tests
             Assert.True(typeof(IIPAddressRange).IsAssignableFrom(ipAddressRangeType));
             Assert.True(typeof(IComparable<IPAddressRange>).IsAssignableFrom(ipAddressRangeType));
             Assert.True(typeof(IEquatable<IPAddressRange>).IsAssignableFrom(ipAddressRangeType));
+            Assert.True(typeof(IComparable).IsAssignableFrom(ipAddressRangeType));
         }
 
         #endregion //end: Class
+
+        #region CompareTo / Operators
+
+        public static IEnumerable<object[]> Comparison_Values()
+        {
+            var ipv4Slash16 = Subnet.Parse("192.168.0.0/16");
+            var ipv6Slash64 = Subnet.Parse("ab:cd::/64");
+            var ipv4Slash20 = Subnet.Parse("192.168.0.0/20");
+            var ipv6Slash96 = Subnet.Parse("ab:cd::/96");
+            var ipv4All = Subnet.Parse("0.0.0.0/0");
+            var ipv6All = Subnet.Parse("::/0");
+            var ipv4Single = Subnet.Parse("0.0.0.0/32");
+            var ipv6Single = Subnet.Parse("::/128");
+
+            yield return new object[] {0, new IPAddressRange(ipv4Slash16.Head, ipv4Slash16.Tail), new IPAddressRange(ipv4Slash16.Head, ipv4Slash16.Tail)};
+            yield return new object[] {0, new IPAddressRange(ipv6Slash64.Head, ipv6Slash64.Tail), new IPAddressRange(ipv6Slash64.Head, ipv6Slash64.Tail)};
+            yield return new object[] {1, new IPAddressRange(ipv4Slash16.Head, ipv4Slash16.Tail), null};
+            yield return new object[] {1, new IPAddressRange(ipv6Slash64.Head, ipv6Slash64.Tail), null};
+            yield return new object[] {1, new IPAddressRange(ipv4Slash16.Head, ipv4Slash16.Tail), new IPAddressRange(ipv4Slash20.Head, ipv4Slash20.Tail)};
+            yield return new object[] {-1, new IPAddressRange(ipv4Slash20.Head, ipv4Slash20.Tail), new IPAddressRange(ipv4Slash16.Head, ipv4Slash16.Tail)};
+            yield return new object[] {1, new IPAddressRange(ipv6Slash64.Head, ipv6Slash64.Tail), new IPAddressRange(ipv6Slash96.Head, ipv6Slash96.Tail)};
+            yield return new object[] {-1, new IPAddressRange(ipv6Slash96.Head, ipv6Slash96.Tail), new IPAddressRange(ipv6Slash64.Head, ipv6Slash64.Tail)};
+            yield return new object[] {-1, new IPAddressRange(ipv4All.Head, ipv4All.Tail), new IPAddressRange(ipv6All.Head, ipv6All.Tail)};
+            yield return new object[] {1, new IPAddressRange(ipv6All.Head, ipv6All.Tail), new IPAddressRange(ipv4All.Head, ipv4All.Tail)};
+            yield return new object[] {-1, new IPAddressRange(ipv4Single.Head, ipv4Single.Tail), new IPAddressRange(ipv6Single.Head, ipv6Single.Tail)};
+            yield return new object[] {1, new IPAddressRange(ipv6Single.Head, ipv6Single.Tail), new IPAddressRange(ipv4Single.Head, ipv4Single.Tail)};
+        }
+
+        [Theory]
+        [MemberData(nameof(Comparison_Values))]
+        public void CompareTo_Test(int expected,
+                                   IPAddressRange left,
+                                   IPAddressRange right)
+        {
+            // Arrange
+            // Act
+            var result = left.CompareTo(right);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [MemberData(nameof(Comparison_Values))]
+        public void Operator_Equals_Test(int expected,
+                                          IPAddressRange left,
+                                          IPAddressRange right)
+        {
+            // Arrange
+            // Act
+            var result = left == right;
+
+            // Assert
+            Assert.Equal(expected == 0, result);
+        }
+
+        [Theory]
+        [MemberData(nameof(Comparison_Values))]
+        public void Operator_NotEquals_Test(int expected,
+                                             IPAddressRange left,
+                                             IPAddressRange right)
+        {
+            // Arrange
+            // Act
+            var result = left != right;
+
+            // Assert
+            Assert.Equal(expected != 0, result);
+        }
+
+        [Theory]
+        [MemberData(nameof(Comparison_Values))]
+        public void Operator_GreaterThan_Test(int expected,
+                                               IPAddressRange left,
+                                               IPAddressRange right)
+        {
+            // Arrange
+            // Act
+            var result = left > right;
+
+            // Assert
+            Assert.Equal(expected > 0, result);
+        }
+
+        [Theory]
+        [MemberData(nameof(Comparison_Values))]
+        public void Operator_GreaterThanOrEqual_Test(int expected,
+                                                      IPAddressRange left,
+                                                      IPAddressRange right)
+        {
+            // Arrange
+            // Act
+            var result = left >= right;
+
+            // Assert
+            Assert.Equal(expected >= 0, result);
+        }
+
+        [Theory]
+        [MemberData(nameof(Comparison_Values))]
+        public void Operator_LessThan_Test(int expected,
+                                            IPAddressRange left,
+                                            IPAddressRange right)
+        {
+            // Arrange
+            // Act
+            var result = left < right;
+
+            // Assert
+            Assert.Equal(expected < 0, result);
+        }
+
+        [Theory]
+        [MemberData(nameof(Comparison_Values))]
+        public void Operator_LessThanOrEqual_Test(int expected,
+                                                   IPAddressRange left,
+                                                   IPAddressRange right)
+        {
+            // Arrange
+            // Act
+            var result = left <= right;
+
+            // Assert
+            Assert.Equal(expected <= 0, result);
+        }
+
+        #endregion end CompareTo / Operators
 
         #region TailOverlappedBy
 

--- a/src/Arcus.Tests/SubnetTests.cs
+++ b/src/Arcus.Tests/SubnetTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -59,42 +59,125 @@ namespace Arcus.Tests
             Assert.True(typeof(IIPAddressRange).IsAssignableFrom(subnetType));
             Assert.True(typeof(IComparable<Subnet>).IsAssignableFrom(subnetType));
             Assert.True(typeof(IEquatable<Subnet>).IsAssignableFrom(subnetType));
+            Assert.True(typeof(IComparable).IsAssignableFrom(subnetType));
         }
 
         #endregion // end: Class
 
-        #region CompareTo
+        #region CompareTo / Operators
+
+        public static IEnumerable<object[]> Comparison_Values()
+        {
+            yield return new object[] {0, Subnet.Parse("192.168.0.0/16"), Subnet.Parse("192.168.0.0/16")};
+            yield return new object[] {0, Subnet.Parse("ab:cd::/64"), Subnet.Parse("ab:cd::/64")};
+            yield return new object[] {1, Subnet.Parse("192.168.0.0/16"), null};
+            yield return new object[] {1, Subnet.Parse("ab:cd::/64"), null};
+            yield return new object[] {1, Subnet.Parse("192.168.0.0/16"), Subnet.Parse("192.168.0.0/20")};
+            yield return new object[] {-1, Subnet.Parse("192.168.0.0/20"), Subnet.Parse("192.168.0.0/16")};
+            yield return new object[] {1, Subnet.Parse("ab:cd::/64"), Subnet.Parse("ab:cd::/96")};
+            yield return new object[] {-1, Subnet.Parse("ab:cd::/96"), Subnet.Parse("ab:cd::/64")};
+            yield return new object[] {-1, Subnet.Parse("0.0.0.0/0"), Subnet.Parse("::/0")};
+            yield return new object[] {1, Subnet.Parse("::/0"), Subnet.Parse("0.0.0.0/0")};
+            yield return new object[] {-1, Subnet.Parse("0.0.0.0/32"), Subnet.Parse("::/128")};
+            yield return new object[] {1, Subnet.Parse("::/128"), Subnet.Parse("0.0.0.0/32")};
+        }
 
         [Theory]
-        [InlineData(0, "192.168.0.0/16", "192.168.0.0/16")]
-        [InlineData(0, "ab:cd::/64", "ab:cd::/64")]
-        [InlineData(1, "192.168.0.0/16", null)]
-        [InlineData(1, "ab:cd::/64", null)]
-        [InlineData(1, "192.168.0.0/16", "192.168.0.0/20")]
-        [InlineData(-1, "192.168.0.0/20", "192.168.0.0/16")]
-        [InlineData(1, "ab:cd::/64", "ab:cd::/96")]
-        [InlineData(-1, "ab:cd::/96", "ab:cd::/64")]
-        [InlineData(-1, "0.0.0.0/0", "::/0")]
-        [InlineData(1, "::/0", "0.0.0.0/0")]
-        [InlineData(-1, "0.0.0.0/32", "::/128")]
-        [InlineData(1, "::/128", "0.0.0.0/32")]
+        [MemberData(nameof(Comparison_Values))]
         public void CompareTo_Test(int expected,
-                                   string x,
-                                   string y)
+                                   Subnet left,
+                                   Subnet right)
         {
             // Arrange
-            var thisSubnet = Subnet.Parse(x);
-
-            if (!Subnet.TryParse(y, out var other))
-            {
-                other = null;
-            }
-
             // Act
-            var result = thisSubnet.CompareTo(other);
+            var result = left.CompareTo(right);
 
             // Assert
             Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [MemberData(nameof(Comparison_Values))]
+        public void Operator_Equals_Test(int expected,
+                                          Subnet left,
+                                          Subnet right)
+        {
+            // Arrange
+            // Act
+            var result = left == right;
+
+            // Assert
+            Assert.Equal(expected == 0, result);
+        }
+
+        [Theory]
+        [MemberData(nameof(Comparison_Values))]
+        public void Operator_NotEquals_Test(int expected,
+                                             Subnet left,
+                                             Subnet right)
+        {
+            // Arrange
+            // Act
+            var result = left != right;
+
+            // Assert
+            Assert.Equal(expected != 0, result);
+        }
+
+        [Theory]
+        [MemberData(nameof(Comparison_Values))]
+        public void Operator_GreaterThan_Test(int expected,
+                                               Subnet left,
+                                               Subnet right)
+        {
+            // Arrange
+            // Act
+            var result = left > right;
+
+            // Assert
+            Assert.Equal(expected > 0, result);
+        }
+
+        [Theory]
+        [MemberData(nameof(Comparison_Values))]
+        public void Operator_GreaterThanOrEqual_Test(int expected,
+                                                      Subnet left,
+                                                      Subnet right)
+        {
+            // Arrange
+            // Act
+            var result = left >= right;
+
+            // Assert
+            Assert.Equal(expected >= 0, result);
+        }
+
+        [Theory]
+        [MemberData(nameof(Comparison_Values))]
+        public void Operator_LessThan_Test(int expected,
+                                            Subnet left,
+                                            Subnet right)
+        {
+            // Arrange
+            // Act
+            var result = left < right;
+
+            // Assert
+            Assert.Equal(expected < 0, result);
+        }
+
+        [Theory]
+        [MemberData(nameof(Comparison_Values))]
+        public void Operator_LessThanOrEqual_Test(int expected,
+                                                   Subnet left,
+                                                   Subnet right)
+        {
+            // Arrange
+            // Act
+            var result = left <= right;
+
+            // Assert
+            Assert.Equal(expected <= 0, result);
         }
 
         #endregion

--- a/src/Arcus/IPAddressRange.cs
+++ b/src/Arcus/IPAddressRange.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -15,8 +15,31 @@ namespace Arcus
     [PublicAPI]
     public class IPAddressRange : AbstractIPAddressRange,
                                   IEquatable<IPAddressRange>,
-                                  IComparable<IPAddressRange>
+                                  IComparable<IPAddressRange>,
+                                  IComparable
     {
+        #region From Interface IComparable
+
+        /// <inheritdoc />
+        public int CompareTo(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return 1;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return 0;
+            }
+
+            return obj is IPAddressRange other
+                       ? this.CompareTo(other)
+                       : throw new ArgumentException($"Object must be of type {nameof(IPAddressRange)}");
+        }
+
+        #endregion
+
         #region From Interface IComparable<IPAddressRange>
 
         /// <inheritdoc />
@@ -34,8 +57,8 @@ namespace Arcus
         {
             return !ReferenceEquals(null, other)
                    && (ReferenceEquals(this, other)
-                       || (Equals(Head, other.Head)
-                       && Equals(Tail, other.Tail)));
+                       || Equals(Head, other.Head)
+                       && Equals(Tail, other.Tail));
         }
 
         #endregion
@@ -45,8 +68,8 @@ namespace Arcus
         {
             return !ReferenceEquals(null, obj)
                    && (ReferenceEquals(this, obj)
-                       || (obj.GetType() == GetType()
-                       && this.Equals((IPAddressRange) obj)));
+                       || obj.GetType() == GetType()
+                       && this.Equals((IPAddressRange) obj));
         }
 
         /// <inheritdoc />
@@ -58,12 +81,96 @@ namespace Arcus
             }
         }
 
+        #region operators
+
+        /// <summary>
+        ///     Compares two <see cref="IPAddressRange" /> objects for equality
+        /// </summary>
+        /// <param name="left">left hand operand</param>
+        /// <param name="right">right hand operand</param>
+        /// <returns><see langword="true" /> when both sides are equal</returns>
+        public static bool operator ==(IPAddressRange left,
+                                       IPAddressRange right)
+        {
+            return Equals(left, right);
+        }
+
+        /// <summary>
+        ///     Compares two <see cref="IPAddressRange" /> objects for non-equality
+        /// </summary>
+        /// <param name="left">left hand operand</param>
+        /// <param name="right">right hand operand</param>
+        /// <returns><see langword="true" /> when both sides are not equal</returns>
+        public static bool operator !=(IPAddressRange left,
+                                       IPAddressRange right)
+        {
+            return !Equals(left, right);
+        }
+
+        /// <summary>
+        ///     Compares two <see cref="IPAddressRange" /> objects for <paramref name="left" /> being less than
+        ///     <paramref name="right" />
+        /// </summary>
+        /// <param name="left">left hand operand</param>
+        /// <param name="right">right hand operand</param>
+        /// <returns><see langword="true" /> when <paramref name="left" /> is less than <paramref name="right" /></returns>
+        public static bool operator <(IPAddressRange left,
+                                      IPAddressRange right)
+        {
+            return Comparer<IPAddressRange>.Default.Compare(left, right) < 0;
+        }
+
+        /// <summary>
+        ///     Compares two <see cref="IPAddressRange" /> objects for <paramref name="left" /> being greater than
+        ///     <paramref name="right" />
+        /// </summary>
+        /// <param name="left">left hand operand</param>
+        /// <param name="right">right hand operand</param>
+        /// <returns><see langword="true" /> when <paramref name="left" /> is greater than <paramref name="right" /></returns>
+        public static bool operator >(IPAddressRange left,
+                                      IPAddressRange right)
+        {
+            return Comparer<IPAddressRange>.Default.Compare(left, right) > 0;
+        }
+
+        /// <summary>
+        ///     Compares two <see cref="IPAddressRange" /> objects for <paramref name="left" /> being less than or equal
+        ///     <paramref name="right" />
+        /// </summary>
+        /// <param name="left">left hand operand</param>
+        /// <param name="right">right hand operand</param>
+        /// <returns>
+        ///     <see langword="true" /> when <paramref name="left" /> is less than or equal to <paramref name="right" />
+        /// </returns>
+        public static bool operator <=(IPAddressRange left,
+                                       IPAddressRange right)
+        {
+            return Comparer<IPAddressRange>.Default.Compare(left, right) <= 0;
+        }
+
+        /// <summary>
+        ///     Compares two <see cref="IPAddressRange" /> objects for <paramref name="left" /> being greater than or equal to
+        ///     <paramref name="right" />
+        /// </summary>
+        /// <param name="left">left hand operand</param>
+        /// <param name="right">right hand operand</param>
+        /// <returns>
+        ///     <see langword="true" /> when <paramref name="left" /> is greater than or equal to <paramref name="right" />
+        /// </returns>
+        public static bool operator >=(IPAddressRange left,
+                                       IPAddressRange right)
+        {
+            return Comparer<IPAddressRange>.Default.Compare(left, right) >= 0;
+        }
+
+        #endregion end operators
+
         #region Ctor
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="IPAddressRange"/> class.
+        ///     Initializes a new instance of the <see cref="IPAddressRange" /> class.
         /// </summary>
-        /// <param name="address">the <see cref="IPAddress"/></param>
+        /// <param name="address">the <see cref="IPAddress" /></param>
         public IPAddressRange([NotNull] IPAddress address)
             : base(address, address)
         {
@@ -71,10 +178,10 @@ namespace Arcus
         }
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="IPAddressRange"/> class.
+        ///     Initializes a new instance of the <see cref="IPAddressRange" /> class.
         /// </summary>
-        /// <param name="head">head <see cref="IPAddress"/></param>
-        /// <param name="tail">tail <see cref="IPAddress"/></param>
+        /// <param name="head">head <see cref="IPAddress" /></param>
+        /// <param name="tail">tail <see cref="IPAddress" /></param>
         public IPAddressRange([NotNull] IPAddress head,
                               [NotNull] IPAddress tail)
             : base(head, tail)
@@ -156,9 +263,12 @@ namespace Arcus
         ///     excluded ranges are expected to each be sub ranges of the initial range
         ///     an attempt will be made to TryCollapseAll the excluded
         /// </summary>
-        /// <param name="initialRange">the initial <see cref="IPAddressRange"/> to exclude from</param>
-        /// <param name="excludedRanges">the various <see cref="IPAddressRange"/> to exclude from the <paramref name="initialRange"/></param>
-        /// <param name="result">the resulting  <see cref="IPAddressRange"/> <see cref="IEnumerable{T}"/></param>
+        /// <param name="initialRange">the initial <see cref="IPAddressRange" /> to exclude from</param>
+        /// <param name="excludedRanges">
+        ///     the various <see cref="IPAddressRange" /> to exclude from the
+        ///     <paramref name="initialRange" />
+        /// </param>
+        /// <param name="result">the resulting  <see cref="IPAddressRange" /> <see cref="IEnumerable{T}" /></param>
         /// <exception cref="InvalidOperationException">unexpected invalid operation.</exception>
         public static bool TryExcludeAll(IPAddressRange initialRange,
                                          IEnumerable<IPAddressRange> excludedRanges,
@@ -271,7 +381,7 @@ namespace Arcus
         /// </summary>
         /// <param name="left">the left operand</param>
         /// <param name="right">the right operand</param>
-        /// <param name="mergedRange">the resulting <see cref="IPAddressRange"/></param>
+        /// <param name="mergedRange">the resulting <see cref="IPAddressRange" /></param>
         public static bool TryMerge(IPAddressRange left,
                                     IPAddressRange right,
                                     out IPAddressRange mergedRange)


### PR DESCRIPTION
CA1036 states that  IPAddressRange and Subnet should override the comparison operators, specifically op_Equality, op_Inequality, op_LessThan and op_GreaterThan.
Added less than or equal to and greater than or equal to so as not to disappoint